### PR TITLE
feat: max-852: Prebid: Log bid win to adserver

### DIFF
--- a/modules/mobkoiBidAdapter.js
+++ b/modules/mobkoiBidAdapter.js
@@ -1,6 +1,7 @@
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
+import { _each, replaceMacros, deepAccess, deepSetValue } from '../src/utils.js';
 
 const BIDDER_CODE = 'mobkoi';
 const DEFAULT_AD_SERVER_BASE_URL = 'https://adserver.mobkoi.com';
@@ -8,6 +9,13 @@ const DEFAULT_AD_SERVER_BASE_URL = 'https://adserver.mobkoi.com';
  * The name of the parameter that the publisher can use to specify the ad server endpoint.
  */
 const PARAM_NAME_AD_SERVER_BASE_URL = 'adServerBaseUrl';
+/**
+ * The list of ORTB response fields that are used in the macros. Field
+ * replacement is self-implemented in the adapter. Use dot-notated path for
+ * nested fields. For example, 'ad.ext.adomain'. For more information, visit
+ * https://www.npmjs.com/package/dset and https://www.npmjs.com/package/dlv.
+ */
+const ORTB_RESPONSE_FIELDS_SUPPORT_MACROS = ['adm', 'nurl', 'lurl'];
 
 const getBidServerEndpointBase = (prebidBidRequest) => {
   return prebidBidRequest.params[PARAM_NAME_AD_SERVER_BASE_URL] || DEFAULT_AD_SERVER_BASE_URL;
@@ -19,10 +27,34 @@ const converter = ortbConverter({
     ttl: 30,
   },
   imp(buildImp, bidRequest, context) {
+    context[PARAM_NAME_AD_SERVER_BASE_URL] = getBidServerEndpointBase(bidRequest);
     return buildImp(bidRequest, context);
   },
   bidResponse(buildPrebidBidResponse, ortbBidResponse, context) {
-    return buildPrebidBidResponse(ortbBidResponse, context);
+    const macros = {
+      // ORTB macros
+      // AUCTION_PRICE: Don't replace the price macro because it's already replaced by Prebid.js.
+      AUCTION_IMP_ID: ortbBidResponse.impid,
+      AUCTION_CURRENCY: ortbBidResponse.cur,
+      AUCTION_BID_ID: context.bidderRequest.auctionId,
+
+      // Custom macros
+      BIDDING_API_BASE_URL: context[PARAM_NAME_AD_SERVER_BASE_URL],
+      CREATIVE_ID: ortbBidResponse.crid,
+      CAMPAIGN_ID: ortbBidResponse.cid,
+    };
+
+    _each(ORTB_RESPONSE_FIELDS_SUPPORT_MACROS, ortbField => {
+      deepSetValue(
+        ortbBidResponse,
+        ortbField,
+        replaceMacros(deepAccess(ortbBidResponse, ortbField), macros)
+      );
+    });
+
+    const prebidBid = buildPrebidBidResponse(ortbBidResponse, context);
+    prebidBid.ortbBidResponse = ortbBidResponse;
+    return prebidBid;
   },
 });
 


### PR DESCRIPTION
> Related PRs https://github.com/mobkoi/adserver/pull/6

### [Prebid: Log bid win to adserver](https://mobkoi.atlassian.net/browse/MAX-852)

Implement logging of bid wins directly to the ad server.

Sub-tasks:

Capture winning bid events in the Prebid.js custom adapter in various steps of biding process.

