### PR TITLE
feat: max-853: Prebid: Log bid loss to adserver

### DIFF
--- a/modules/mobkoiAnalyticsAdapter.js
+++ b/modules/mobkoiAnalyticsAdapter.js
@@ -1,0 +1,67 @@
+import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import adapterManager from '../src/adapterManager.js';
+import { EVENTS } from '../src/constants.js';
+import { logInfo } from '../src/utils.js';
+
+const BIDDER_CODE = 'mobkoi';
+const analyticsType = 'endpoint';
+const GVL_ID = 898;
+
+let initOptions = {};
+
+let mobkoiAnalytics = Object.assign(adapter({analyticsType}), {
+  track({
+    eventType,
+    args
+  }) {
+    logInfo(`eventType: ${eventType}`, args);
+
+    // switch (eventType) {
+    //   case EVENTS.AUCTION_INIT:
+    //     logInfo(`eventType: ${eventType}`, args);
+    //     // handleAuctionInit(eventType, args);
+    //     break;
+    //   case EVENTS.BID_REQUESTED:
+    //     logInfo(`eventType: ${eventType}`, args);
+    //     // handleBidRequested(args);
+    //     break;
+    //   case EVENTS.BID_RESPONSE:
+    //     logInfo(`eventType: ${eventType}`, args);
+    //     // handleBidResponse(eventType, args);
+    //     break;
+    //   case EVENTS.NO_BID:
+    //     logInfo(`eventType: ${eventType}`, args);
+    //     // handleNoBid(eventType, args);
+    //     break;
+    //   case EVENTS.BID_TIMEOUT:
+    //     logInfo(`eventType: ${eventType}`, args);
+    //     // handleBidTimeout(eventType, args);
+    //     break;
+    //   case EVENTS.BID_WON:
+    //     logInfo(`eventType: ${eventType}`, args);
+    //     // handleBidWon(eventType, args);
+    //     break;
+    //   case EVENTS.AUCTION_END:
+    //     logInfo(`eventType: ${eventType}`, args);
+    //     // handleAuctionEnd();
+    // }
+  }
+});
+
+// save the base class function
+mobkoiAnalytics.originEnableAnalytics = mobkoiAnalytics.enableAnalytics;
+
+// override enableAnalytics so we can get access to the config passed in from the page
+mobkoiAnalytics.enableAnalytics = function (config) {
+  initOptions = config.options;
+  logInfo('mobkoiAnalytics.enableAnalytics', initOptions);
+  mobkoiAnalytics.originEnableAnalytics(config); // call the base class function
+};
+
+adapterManager.registerAnalyticsAdapter({
+  adapter: mobkoiAnalytics,
+  code: BIDDER_CODE,
+  gvlid: GVL_ID
+});
+
+export default mobkoiAnalytics;

--- a/modules/mobkoiAnalyticsAdapter.js
+++ b/modules/mobkoiAnalyticsAdapter.js
@@ -88,6 +88,9 @@ let mobkoiAnalytics = Object.assign(adapter({analyticsType}), {
         triggerAllLossBidLossBeacon(args, this.mobkoiContext);
         break;
       case BIDDER_DONE:
+        if (args.bidderCode !== BIDDER_CODE) {
+          break;
+        }
         triggerAllLossBidLossBeacon(args, this.mobkoiContext);
         break;
       default:

--- a/modules/mobkoiAnalyticsAdapter.md
+++ b/modules/mobkoiAnalyticsAdapter.md
@@ -1,0 +1,9 @@
+# Overview
+
+Module Name: Mobkoi Analytics Adapter
+Module Type: Analytics Adapter
+Maintainer: platform@mobkoi.com
+
+# Description
+
+Analytics adapter for Mobkoi. Contact platform@mobkoi.com for information.

--- a/modules/mobkoiAnalyticsAdapter.md
+++ b/modules/mobkoiAnalyticsAdapter.md
@@ -2,8 +2,8 @@
 
 Module Name: Mobkoi Analytics Adapter
 Module Type: Analytics Adapter
-Maintainer: platform@mobkoi.com
+Maintainer: platformteam@mobkoi.com
 
 # Description
 
-Analytics adapter for Mobkoi. Contact platform@mobkoi.com for information.
+Analytics adapter for Mobkoi. Contact platformteam@mobkoi.com for information.

--- a/modules/mobkoiBidAdapter.js
+++ b/modules/mobkoiBidAdapter.js
@@ -57,8 +57,9 @@ export const converter = ortbConverter({
     });
 
     const prebidBid = buildPrebidBidResponse(ortbBidResponse, context);
+    // Save the ORTB response for later use in the other parts of the adapter as
+    // well as the within the analytics adapter.
     prebidBid.ortbBid = ortbBidResponse;
-    console.log('prebidBid', prebidBid);
     return prebidBid;
   },
 });

--- a/modules/mobkoiBidAdapter.js
+++ b/modules/mobkoiBidAdapter.js
@@ -25,7 +25,7 @@ const getBidServerEndpointBase = (prebidBidRequest) => {
   return adServerBaseUrl;
 }
 
-const converter = ortbConverter({
+export const converter = ortbConverter({
   context: {
     netRevenue: true,
     ttl: 30,
@@ -37,7 +37,7 @@ const converter = ortbConverter({
   bidResponse(buildPrebidBidResponse, ortbBidResponse, context) {
     const macros = {
       // ORTB macros
-      // AUCTION_PRICE: Don't replace the price macro because it's already replaced by Prebid.js.
+      AUCTION_PRICE: ortbBidResponse.price,
       AUCTION_IMP_ID: ortbBidResponse.impid,
       AUCTION_CURRENCY: ortbBidResponse.cur,
       AUCTION_BID_ID: context.bidderRequest.auctionId,
@@ -57,7 +57,8 @@ const converter = ortbConverter({
     });
 
     const prebidBid = buildPrebidBidResponse(ortbBidResponse, context);
-    prebidBid.ortbBidResponse = ortbBidResponse;
+    prebidBid.ortbBid = ortbBidResponse;
+    console.log('prebidBid', prebidBid);
     return prebidBid;
   },
 });

--- a/modules/mobkoiBidAdapter.js
+++ b/modules/mobkoiBidAdapter.js
@@ -4,7 +4,6 @@ import { BANNER } from '../src/mediaTypes.js';
 import { _each, replaceMacros, deepAccess, deepSetValue } from '../src/utils.js';
 
 const BIDDER_CODE = 'mobkoi';
-const DEFAULT_AD_SERVER_BASE_URL = 'https://adserver.mobkoi.com';
 /**
  * The name of the parameter that the publisher can use to specify the ad server endpoint.
  */
@@ -18,7 +17,12 @@ const PARAM_NAME_AD_SERVER_BASE_URL = 'adServerBaseUrl';
 const ORTB_RESPONSE_FIELDS_SUPPORT_MACROS = ['adm', 'nurl', 'lurl'];
 
 const getBidServerEndpointBase = (prebidBidRequest) => {
-  return prebidBidRequest.params[PARAM_NAME_AD_SERVER_BASE_URL] || DEFAULT_AD_SERVER_BASE_URL;
+  const adServerBaseUrl = prebidBidRequest.params[PARAM_NAME_AD_SERVER_BASE_URL];
+
+  if (!adServerBaseUrl) {
+    throw new Error(`The "${PARAM_NAME_AD_SERVER_BASE_URL}" parameter is required in Ad unit bid params.`);
+  }
+  return adServerBaseUrl;
 }
 
 const converter = ortbConverter({


### PR DESCRIPTION
### [Prebid: Log bid loss to adserver](https://mobkoi.atlassian.net/browse/MAX-853)

Implement logging of failed bid events for monitoring purposes.

Sub-tasks:

Initialise a Prebid custom analytic adapter.

Capture bid failure events within Prebid.js during various steps of the bidding process

Initialise the endpoint for receiving bid loss signals. 

Logs will log into Grafana, but this will be done in a separate ticket
