### PR TITLE
feat: max-970: Prebid.js Bidder Adapter: Retrieve Adapter Parameters from Bid Configuration Object

### DIFF
--- a/modules/mobkoiBidAdapter.js
+++ b/modules/mobkoiBidAdapter.js
@@ -52,12 +52,15 @@ export const spec = {
   supportedMediaTypes: [BANNER],
   gvlid: GVL_ID,
 
+  /**
+   * Determines whether or not the given bid request is valid.
+   */
   isBidRequestValid(bid) {
     if (
       !deepAccess(bid, `params.${PUBLISHER_PARAMS.PARAM_NAME_PUBLISHER_ID}`) &&
       !deepAccess(bid, 'ortb2.site.publisher.id')
     ) {
-      logError(`The ${PUBLISHER_PARAMS.PARAM_NAME_PUBLISHER_ID} field is required in the bid request.` +
+      logError(`The ${PUBLISHER_PARAMS.PARAM_NAME_PUBLISHER_ID} field is required in the bid request. ` +
         'Please follow the setup guideline to set the publisher ID field.'
       );
       return false;
@@ -75,7 +78,9 @@ export const spec = {
 
     return true;
   },
-
+  /**
+   * Make a server request from the list of BidRequests.
+   */
   buildRequests(prebidBidRequests, prebidBidderRequest) {
     const adServerEndpoint = utils.getAdServerEndpointBaseUrl(prebidBidderRequest) + '/bid';
 
@@ -91,7 +96,9 @@ export const spec = {
       }),
     };
   },
-
+  /**
+   * Unpack the response from the server into a list of bids.
+   */
   interpretResponse(serverResponse, customBidRequest) {
     if (!serverResponse.body) return [];
 

--- a/modules/mobkoiBidAdapter.js
+++ b/modules/mobkoiBidAdapter.js
@@ -4,6 +4,7 @@ import { BANNER } from '../src/mediaTypes.js';
 import { _each, replaceMacros, deepAccess, deepSetValue, logError } from '../src/utils.js';
 
 const BIDDER_CODE = 'mobkoi';
+const GVL_ID = 898;
 /**
  * !IMPORTANT: This value must match the value in mobkoiAnalyticsAdapter.js
  * The name of the parameter that the publisher can use to specify the ad server endpoint.
@@ -42,6 +43,7 @@ export const converter = ortbConverter({
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER],
+  gvlid: GVL_ID,
 
   isBidRequestValid(bid) {
     if (!deepAccess(bid, 'ortb2.site.publisher.id')) {
@@ -85,7 +87,6 @@ export const spec = {
 registerBidder(spec);
 
 export const utils = {
-
   /**
    * !IMPORTANT: Make sure the implementation of this function matches getAdServerEndpointBaseUrl
    * in both adapters.


### PR DESCRIPTION
### [Prebid.js Bidder Adapter: Retrieve Adapter Parameters from Bid Configuration Object](https://mobkoi.atlassian.net/browse/MAX-970)

At this stage, we are only focused on bid win events, so there is no need for analytics adapter integration yet. To streamline the publisher's configuration for our custom bid adapter integration, we retrieve adapter parameters directly from the bid configuration object instead of using "bidderConfiguration."